### PR TITLE
Updated: Created Separate Thread for Memory Leak

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/PerformanceResource.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PerformanceResource.java
@@ -37,18 +37,30 @@ public class PerformanceResource {
 		 * 120MB in bytes
 		 */ // long initialHeapSize = Runtime.getRuntime().totalMemory();
 		memoryLeakList.clear();
-
+		memroyLeak = new Thread(()->{
 		List<Object> memoryLeakList = new ArrayList<>();
 		int i = 0;
 		Thread.currentThread().setName("Pet-MemoryLeak");
 		while (i <= 110) {
 			memoryLeakList.add(new byte[1024 * 1024]);
-			Thread.sleep(5);
+			try {
+				Thread.sleep(5);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
 			i++;
 		}
-		Thread.sleep(600000);
+		try {
+			Thread.sleep(600000);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		executorService = Executors.newSingleThreadScheduledExecutor();
+		executorService.schedule(this::stopCpuUsage, 10, TimeUnit.MINUTES);
 		memoryLeakList.clear();
 		System.gc();
+		} );
+		memroyLeak.start();
 		return "performance/performance";
 	}
 


### PR DESCRIPTION
**Issue/Enhancement:**
 - Memory Leak is run on main thread. This call is not traced immediately, since it does not return the response until 10 minutes. Once repsonse is returned it traced . Also, it makes the application page to non responsive for 10 minutes.
**Implemented Changes:**
 - Created the new thread "Pet-MemoryLeak" and assigned the memory leak task to the thread.
 **Testing:**
 - Tested the memory leak using JConsole, which successfully stops and clears memory after a 10-minute interval.

![MicrosoftTeams-image (1)](https://github.com/pramurthy/spring-petclinic/assets/135807462/e07dbef9-b10b-45ae-ad0b-62df05099634)
![Screenshot 2023-08-23 124203](https://github.com/pramurthy/spring-petclinic/assets/135807462/94f00871-c1bc-49b3-9399-6158f4fa6eb3)
